### PR TITLE
Moved from label-level parallelism to document-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["topic", "nlp", "phrase"]
 edition = "2018"
 
 [dependencies]
-
 rocket = "0.4"
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
I found that I couldn't exploit parallelism at all with my dataset due to the fact that the only parallel iterator in the program splits the work up per label (see `update_phrase_model()`). Hence, if you have a dataset without labels, all work would go on a single thread.

I propose to change that with this PR. Each document is now sent to a different core.
This implementation becomes more efficient with larger batch sizes.

Note that the documents in the batch are now also sorted in parallel (`documents.par_sort_unstable`). I would love to hear _why_ they are sorted though, does this enable some kind of downstream optimization?

I haven't tested it in-depth yet, as I don't really have a gold standard. However, looking at the code, the scores produced should remain unchanged.

Let me know what you think! Happy to apply any changes you deem necessary.